### PR TITLE
Orientation check fix to check when changing from w.orientation === 180, not just 0.

### DIFF
--- a/ios-orientationchange-fix.js
+++ b/ios-orientationchange-fix.js
@@ -39,7 +39,7 @@
 		z = Math.abs( aig.z );
 				
 		// If portrait orientation and in one of the danger zones
-        if( !w.orientation && ( x > 7 || ( ( z > 6 && y < 8 || z < 8 && y > 6 ) && x > 5 ) ) ){
+        if( (!w.orientation || w.orientation === 180) && ( x > 7 || ( ( z > 6 && y < 8 || z < 8 && y > 6 ) && x > 5 ) ) ){
 			if( enabled ){
 				disableZoom();
 			}        	


### PR DESCRIPTION
Orientation check currently only checks for portrait when the iP\* is
held right side up. Added check for w.orientation === 180 to check for
portrait when the iP\* is held upside down.
